### PR TITLE
Moved from unconstrained futures to pipeline-blocking

### DIFF
--- a/src/witan/send/adroddiad/simulated_transition_counts.clj
+++ b/src/witan/send/adroddiad/simulated_transition_counts.clj
@@ -1,25 +1,37 @@
 (ns witan.send.adroddiad.simulated-transition-counts
-  (:require [tablecloth.api :as tc]
-            [tech.v3.dataset :as ds]
-            [tech.v3.datatype.functional :as dfn]
-            [tech.v3.dataset.reductions :as ds-reduce]
+  (:require [clojure.core.async :as a]
+            [tablecloth.api :as tc]
             [witan.send.adroddiad.simulated-transition-counts.io :as stcio]))
 
 (defn transit->dataset-multi-threaded [input-dir]
-  (let [all-datasets (into []
-                           (comp
-                            stcio/gzipped-transit-file-paths-xf
-                            (map (fn [file] (stcio/transit-file->eduction file)))
-                            (map (fn [e] (future (tc/dataset (into [] e))))))
-                           (stcio/sorted-file-list input-dir))]
-    (apply tc/concat-copying (map deref all-datasets))))
+  (let [concurrent (max 2 (dec (.. Runtime getRuntime availableProcessors)))
+        output-chan (a/chan)]
+    (a/pipeline-blocking concurrent
+                         output-chan
+                         (comp
+                          stcio/gzipped-transit-file-paths-xf
+                          (map (fn [file] (stcio/transit-file->eduction file)))
+                          (map (fn [e] (-> (into [] e)
+                                           (tc/dataset)
+                                           (tc/convert-types {:calendar-year :int16
+                                                              :academic-year-1 :int16
+                                                              :academic-year-2 :int16
+                                                              :simulation :int16
+                                                              :transition-count :int16})))))
+                         (a/to-chan (stcio/sorted-file-list input-dir)))
+    (apply tc/concat-copying (a/<!! (a/into [] output-chan)))))
 
 (defn full-simulation-multi-threaded [simulation-input-dir historic-transitions-file-name]
   (let [simulation-data (transit->dataset-multi-threaded simulation-input-dir)
         historic-data (-> (tc/dataset historic-transitions-file-name)
                           (tc/add-column "transition-count" 1)
                           (tc/add-column "simulation" -1)
-                          (tc/rename-columns :all keyword))]
+                          (tc/rename-columns :all keyword)
+                          (tc/convert-types {:calendar-year :int16
+                                             :academic-year-1 :int16
+                                             :academic-year-2 :int16
+                                             :simulation :int16
+                                             :transition-count :int16}))]
     (tc/concat-copying historic-data
                        simulation-data)))
 


### PR DESCRIPTION
And made incoming integers a smaller size to decrease overall memory
size.