### PR TITLE
Make palette an argument to colors-and-shapes

### DIFF
--- a/src/witan/send/adroddiad/chart_utils.clj
+++ b/src/witan/send/adroddiad/chart_utils.clj
@@ -19,7 +19,11 @@
           (conj (vals (domains census-data))
                 extra-domain-items)) palette))
   ([census-data extra-domain-items]
-   (colors-and-shapes census-data extra-domain-items))
+   (colors/domain-colors-and-shapes
+    (into []
+          cat
+          (conj (vals (domains census-data))
+                extra-domain-items))))
   ([census-data]
    (colors-and-shapes census-data [])))
 


### PR DESCRIPTION
You can now pick your own palette to us for colors-and-shapes (and I did it without breaking anything previous). The only thing I don't like about it is that you have to provide something to the `extra-domain-items` argument, even if it's just an empty vector. I'd like to make the input to colors-and-shapes a map, but that would break previous thing 🤷 