### PR TITLE
Allow additional columns in output CSVs

### DIFF
--- a/src/witan/send/adroddiad/census/output.clj
+++ b/src/witan/send/adroddiad/census/output.clj
@@ -1,14 +1,18 @@
 (ns witan.send.adroddiad.census.output
   (:require [tablecloth.api :as tc]))
 
-(defn census-columns [census]
-  (tc/select-columns
-   census
-   [:id :calendar-year
-    :setting :need :academic-year]))
+(def census-column-names
+  [:id :calendar-year
+   :setting :need :academic-year])
 
-(defn ->csv-with-ids [census out-file]
-  (-> census
-      census-columns
-      (tc/order-by [:id :calendar-year])
-      (tc/write! out-file)))
+(defn census-columns [census]
+  (tc/select-columns census census-column-names))
+
+(defn ->csv-with-ids
+  ([census out-file]
+   (->csv-with-ids census out-file []))
+  ([census out-file additional-column-names]
+   (-> census
+       (tc/select-columns ((comp distinct concat) census-column-names additional-column-names))
+       (tc/order-by [:id :calendar-year])
+       (tc/write! out-file))))

--- a/src/witan/send/adroddiad/transitions/output.clj
+++ b/src/witan/send/adroddiad/transitions/output.clj
@@ -2,19 +2,22 @@
   (:require [tablecloth.api :as tc]
             [witan.send.adroddiad.transitions :as t]))
 
-(defn ->csv-with-ids [transitions out-file]
-  (-> transitions
-      (tc/select-columns [:id :calendar-year
-                          :setting-1 :need-1 :academic-year-1
-                          :setting-2 :need-2 :academic-year-2
-                          :transition-type])
-      (tc/order-by [:id :calendar-year])
-      (tc/map-columns :transition-type [:setting-1 :setting-2] t/transition-type)
-      (tc/write! out-file)))
+(def transition-column-names
+  [:calendar-year
+   :setting-1 :need-1 :academic-year-1
+   :setting-2 :need-2 :academic-year-2])
+
+(defn ->csv-with-ids
+  ([transitions out-file]
+   (->csv-with-ids transitions out-file []))
+  ([transitions out-file additional-column-names]
+   (-> transitions
+       (tc/map-columns :transition-type [:setting-1 :setting-2] t/transition-type)
+       (tc/select-columns ((comp distinct concat) [:id] transition-column-names [:transition-type] additional-column-names))
+       (tc/order-by [:id :calendar-year])
+       (tc/write! out-file))))
 
 (defn ->csv-model-ready [transitions out-file]
   (-> transitions
-      (tc/select-columns [:calendar-year
-                          :setting-1 :need-1 :academic-year-1
-                          :setting-2 :need-2 :academic-year-2])
+      (tc/select-columns transition-column-names)
       (tc/write! out-file)))


### PR DESCRIPTION
- Factor core census/transition column names into externally accessible def
- Add optional to ->csv-with-ids to include additional columns (ensuring that the core columns come first in the expected order).