### PR TITLE
Move from RCF to RCT tests and add age calculation

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,13 +1,13 @@
 {:paths ["src" "resources"]
- :deps  {org.clojure/clojure       {:mvn/version "1.11.1"}
-         mastodonc/kixi.plot       {:git/url "https://github.com/MastodonC/kixi.plot.git"
-                                    :sha     "0ff3ef59a584a337883f165b57785c65815a49db"}
-         mastodonc/kixi.large      {:git/url "https://github.com/MastodonC/kixi.large.git"
-                                    :sha     "c593467394c7007b565fbd395afe00920c6d334d"}
-         reducibles/reducibles     {:mvn/version "0.3.0"}
-         com.cognitect/transit-clj {:mvn/version "1.0.324"}
-         org.clojure/core.async    {:mvn/version "1.5.648"}
-         com.hyperfiddle/rcf       {:mvn/version "20220926-202227"}}
+ :deps  {org.clojure/clojure                        {:mvn/version "1.11.1"}
+         mastodonc/kixi.plot                        {:git/url "https://github.com/MastodonC/kixi.plot.git"
+                                                     :sha     "0ff3ef59a584a337883f165b57785c65815a49db"}
+         mastodonc/kixi.large                       {:git/url "https://github.com/MastodonC/kixi.large.git"
+                                                     :sha     "c593467394c7007b565fbd395afe00920c6d334d"}
+         reducibles/reducibles                      {:mvn/version "0.3.0"}
+         com.cognitect/transit-clj                  {:mvn/version "1.0.324"}
+         org.clojure/core.async                     {:mvn/version "1.5.648"}
+         io.github.matthewdowney/rich-comment-tests {:git/tag "v1.0.3" :git/sha "a8711e9"}}
  :aliases
  {:test    {:extra-paths ["test"]
             :extra-deps  {org.clojure/test.check {:mvn/version "1.1.0"}}}

--- a/src/witan/send/adroddiad/ncy.clj
+++ b/src/witan/send/adroddiad/ncy.clj
@@ -2,7 +2,7 @@
   "Definitions and functions for handling National Curriculum Year"
   (:require [clojure.set :as set]
             [tablecloth.api :as tc]
-            [hyperfiddle.rcf :as rcf]))
+            [com.mjdowney.rich-comment-tests :as rct]))
 
 
 ;;; # Utility functions
@@ -10,6 +10,53 @@
   "Returns a lazy seq of nums from `start` (inclusive) to `end` (inclusive), by step 1"
   [start end]
   (range start (inc end)))
+
+
+;;; # Age at the start of the school year
+(defn age-at-start-of-school-year-for-census-year
+  "Age on 31st August on year prior to `cy`, in completed years, for child born in month `dob-month` of year `dob-year`.
+
+  NOTE: Age is on 31st August *prior* to `cy`:
+        - E.g. for `cy`=2020, age is calculated on 31-Aug-2019, i.e. at the start of the 2019/20 school year.
+        - The use of the second calendar year of the school year reflects the timing of the SEN2 census in January.
+
+  Age at the start of the school/academic year is the age on 31st August
+  prior to the school/academic year, per:
+
+  - The [gov.uk website](https://www.gov.uk/schools-admissions/school-starting-age),
+  which (as of 23-NOV-2022) states:
+  \"Most children start school full-time in the September after their
+  fourth birthday. This means they’ll turn 5 during their first school
+  year. For example, if your child’s fourth birthday is between 1
+  September 2021 and 31 August 2022 they will usually start school in
+  September 2022.\".
+
+  - The [2022 SEN2 guide](https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1013751/SEN2_2022_Guide.pdf),
+  which states in section 2, part 1, item 1.1 that: \"age breakdown
+  refers to age as at 31 August 2021\", implying (since this is for
+  the January 2022 SEN2 return) that age for SEN2 breakdowns is as of
+  31-AUG prior to starting the school year.
+  "
+  [cy dob-year dob-month]
+  (- cy 1 dob-year (if (< 8 dob-month) 1 0)))
+
+
+;;; ## Tests for age
+(comment
+  (rct/run-ns-tests! *ns*)
+  )
+^:rct/test
+(comment
+  ;; A child born on 01-Sep-2016 would be 3 at the start of the 2020/21 school year.
+  (age-at-start-of-school-year-for-census-year 2021 2016 9) ;=> 3
+  ;; A child born on 31-Aug-2016 would be 4 at the start of the 2020/21 school year.
+  (age-at-start-of-school-year-for-census-year 2021 2016 8) ;=> 4
+  ;; A child born on 31-Aug-2016 would be 0 at the start of the 2016/17 school year.
+  (age-at-start-of-school-year-for-census-year 2017 2016 8) ;=> 0
+  ;; Note that the algorithm will return -ve ages:
+  (age-at-start-of-school-year-for-census-year 2017 2016 9) ;=> -1
+  )
+
 
 
 ;;; # National Curriculum Years and ages
@@ -32,24 +79,7 @@
   is by linear extrapolation, such that the offset between NCY and age
   at the beginning of the school/academic year is +4.
 
-  Age at the start of the school/academic year is the age on 31st August
-  prior to the school/academic year. This is per:
-
-  - The [gov.uk website](https://www.gov.uk/schools-admissions/school-starting-age),
-  which (as of 23-NOV-2022) states:
-  \"Most children start school full-time in the September after their
-  fourth birthday. This means they’ll turn 5 during their first school
-  year. For example, if your child’s fourth birthday is between 1
-  September 2021 and 31 August 2022 they will usually start school in
-  September 2022.\".
-
-  - The [2022 SEN2 guide](https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1013751/SEN2_2022_Guide.pdf),
-  which states in section 2, part 1, item 1.1 that: \"age breakdown
-  refers to age as at 31 August 2021\", implying (since this is for
-  the January 2022 SEN2 return) that age for SEN2 breakdowns is as of
-  31-AUG prior to starting the school year.
-
-  The maximum age for SEND is 25, but per the relevant legistlation
+  The maximum age for SEND is 25, but per the relevant legislation
   \"a local authority may continue to maintain an EHC plan for a young
   person until the end of the academic year during which the young
   person attains the age of 25\", such that they will have been 24 at
@@ -72,24 +102,7 @@
   is by linear extrapolation, such that the offset between NCY and age
   at the beginning of the school/academic year is -4.
 
-  Age at the start of the school/academic year is the age on 31st August
-  prior to the school/academic year. This is per:
-
-  - The [gov.uk website](https://www.gov.uk/schools-admissions/school-starting-age),
-  which (as of 23-NOV-2022) states:
-  \"Most children start school full-time in the September after their
-  fourth birthday. This means they’ll turn 5 during their first school
-  year. For example, if your child’s fourth birthday is between 1
-  September 2021 and 31 August 2022 they will usually start school in
-  September 2022.\".
-
-  - The [2022 SEN2 guide](https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1013751/SEN2_2022_Guide.pdf),
-  which states in section 2, part 1, item 1.1 that: \"age breakdown
-  refers to age as at 31 August 2021\", implying (since this is for
-  the January 2022 SEN2 return) that age for SEN2 breakdowns is as of
-  31-AUG prior to starting the school year.
-
-  The maximum age for SEND is 25, but per the relevant legistlation
+  The maximum age for SEND is 25, but per the relevant legislation
   \"a local authority may continue to maintain an EHC plan for a young
   person until the end of the academic year during which the young
   person attains the age of 25\", such that they will have been 24 at
@@ -97,6 +110,70 @@
   this map is 24 (NCY 20).
   "
   (set/map-invert ncy->age-at-start-of-school-year))
+
+
+;;; ## National Curriculum Year Table
+(comment
+  (-> (tc/dataset {:ncy ncys})
+      (tc/map-columns :age-at-start-of-school-year [:ncy] #(ncy->age-at-start-of-school-year %))
+      (tc/map-columns :age-at-end-of-school-year [:age-at-start-of-school-year] #(inc %))
+      (tc/set-dataset-name "National Curriculum Year Table"))
+  ;; => National Curriculum Year Table [25 3]:
+  ;;    | :ncy | :age-at-start-of-school-year | :age-at-end-of-school-year |
+  ;;    |-----:|-----------------------------:|---------------------------:|
+  ;;    |   -4 |                            0 |                          1 |
+  ;;    |   -3 |                            1 |                          2 |
+  ;;    |   -2 |                            2 |                          3 |
+  ;;    |   -1 |                            3 |                          4 |
+  ;;    |    0 |                            4 |                          5 |
+  ;;    |    1 |                            5 |                          6 |
+  ;;    |    2 |                            6 |                          7 |
+  ;;    |    3 |                            7 |                          8 |
+  ;;    |    4 |                            8 |                          9 |
+  ;;    |    5 |                            9 |                         10 |
+  ;;    |  ... |                          ... |                        ... |
+  ;;    |   10 |                           14 |                         15 |
+  ;;    |   11 |                           15 |                         16 |
+  ;;    |   12 |                           16 |                         17 |
+  ;;    |   13 |                           17 |                         18 |
+  ;;    |   14 |                           18 |                         19 |
+  ;;    |   15 |                           19 |                         20 |
+  ;;    |   16 |                           20 |                         21 |
+  ;;    |   17 |                           21 |                         22 |
+  ;;    |   18 |                           22 |                         23 |
+  ;;    |   19 |                           23 |                         24 |
+  ;;    |   20 |                           24 |                         25 |
+  )
+
+
+;;; ## Tests for ncy->age… and age…->ncy
+(comment
+  (rct/run-ns-tests! *ns*)
+  )
+^:rct/test
+(comment
+  ;; Age at start of reception should be 4 years, per gov.uk/schools-admissions/school-starting-age.
+  (ncy->age-at-start-of-school-year 0) ;=> 4
+
+  ;; Age at start of NCY -4 to 20 should be 0 to 24 respectively.
+  (map ncy->age-at-start-of-school-year (range -4 (inc 20))) ;=>> (range 0  (inc 24))
+
+  ;; ncy->age… should return nil for non-integer NCYs outside -4 to 20 inclusive.
+  (map ncy->age-at-start-of-school-year [-5 0.5 21]) ;=>> '(nil nil nil)
+
+  ;; NCY entered at age 4 should be 0 (reception), per gov.uk/schools-admissions/school-starting-age.
+  (age-at-start-of-school-year->ncy 4) ;=> 0
+
+  ;; NCY entered at age 0 to 24 should be -4 to 20 respectively.
+  (map age-at-start-of-school-year->ncy (range  0 (inc 24))) ;=>> (range -4 (inc 20))
+
+  ;; Round trip test: ncy->age… followed by age…->ncy should return the same for integers -4 to 20 inclusive.
+  (map (comp age-at-start-of-school-year->ncy ncy->age-at-start-of-school-year) (range -4 (inc 20))) ;=>> (range -4 (inc 20))
+
+  ;; age…->ncy should return nil for non-integer age outside 0 to 24 inclusive.
+  (map age-at-start-of-school-year->ncy [-1 0.5 25]) ;=>> '(nil nil nil)
+  )
+
 
 
 ;;; # Imputation for missing National Curriculum Year
@@ -180,177 +257,126 @@
          (tc/drop-columns #(= "_ref" %) :src-table-name)))))
 
 
-(comment
-  ;;; # National Curriculum Year Table
-  (-> (tc/dataset {:ncy ncys})
-      (tc/map-columns :age-at-start-of-school-year [:ncy] #(ncy->age-at-start-of-school-year %))
-      (tc/map-columns :age-at-end-of-school-year [:age-at-start-of-school-year] #(inc %))
-      (tc/set-dataset-name "National Curriculum Year Table"))
-  ;; => National Curriculum Year Table [25 3]:
-  ;;    | :ncy | :age-at-start-of-school-year | :age-at-end-of-school-year |
-  ;;    |-----:|-----------------------------:|---------------------------:|
-  ;;    |   -4 |                            0 |                          1 |
-  ;;    |   -3 |                            1 |                          2 |
-  ;;    |   -2 |                            2 |                          3 |
-  ;;    |   -1 |                            3 |                          4 |
-  ;;    |    0 |                            4 |                          5 |
-  ;;    |    1 |                            5 |                          6 |
-  ;;    |    2 |                            6 |                          7 |
-  ;;    |    3 |                            7 |                          8 |
-  ;;    |    4 |                            8 |                          9 |
-  ;;    |    5 |                            9 |                         10 |
-  ;;    |  ... |                          ... |                        ... |
-  ;;    |   10 |                           14 |                         15 |
-  ;;    |   11 |                           15 |                         16 |
-  ;;    |   12 |                           16 |                         17 |
-  ;;    |   13 |                           17 |                         18 |
-  ;;    |   14 |                           18 |                         19 |
-  ;;    |   15 |                           19 |                         20 |
-  ;;    |   16 |                           20 |                         21 |
-  ;;    |   17 |                           21 |                         22 |
-  ;;    |   18 |                           22 |                         23 |
-  ;;    |   19 |                           23 |                         24 |
-  ;;    |   20 |                           24 |                         25 |
-  )
 
-
-;;; # Tests
-;;; ## Tests for ncy->age… and age…->ncy
-(rcf/tests "Age at start of reception should be 4 years, per gov.uk/schools-admissions/school-starting-age"
-           (ncy->age-at-start-of-school-year 0) := 4)
-
-(rcf/tests
- "Age at start of NCY -4 to 20 should be 0 to 24 respectively"
- (map ncy->age-at-start-of-school-year (range -4 (inc 20))) := (range 0  (inc 24)))
-
-(rcf/tests
- "ncy->age… should return nil for non-integer NCYs outside -4 to 20 inclusive"
- (map ncy->age-at-start-of-school-year [-5 0.5 21]) := '(nil nil nil))
-
-(rcf/tests
- "NCY entered at age 4 should be 0 (reception), per gov.uk/schools-admissions/school-starting-age"
- (age-at-start-of-school-year->ncy 4) := 0)
-
-(rcf/tests
- "NCY entered at age 0 to 24 should be -4 to 20 respectively"
- (map age-at-start-of-school-year->ncy (range  0 (inc 24))) := (range -4 (inc 20)))
-
-(rcf/tests
- "Round trip test: ncy->age… followed by age…->ncy should return the same for integers -4 to 20 inclusive"
- (map (comp age-at-start-of-school-year->ncy ncy->age-at-start-of-school-year) (range -4 (inc 20))) := (range -4 (inc 20)))
-
-(rcf/tests
- "age…->ncy should return nil for non-integer age outside 0 to 24 inclusive"
- (map age-at-start-of-school-year->ncy [-1 0.5 25]) := '(nil nil nil))
 
 
 ;;; ## Tests for impute-nil-ncy
-(rcf/tests
- "Where all `ncy` are nil (so no reference rows), should not blow up
- and should return input dataset (including any other columns -
- here :row-id) with add nil `ncy-imputation` column added."
- (let [test-ds (-> (tc/concat (tc/dataset {:id  1 :calendar-year [2000 2001 2002] :academic-year      nil     })
-                              (tc/dataset {:id  2 :calendar-year [2000 2001 2002] :academic-year      nil     }))
-                   (tc/add-column :row-id (range)))]
-   (impute-nil-ncy test-ds) := (tc/add-column test-ds :academic-year-imputation nil)))
+(comment
+  (rct/run-ns-tests! *ns*)
+  )
+^:rct/test
+(comment
+  ;; Where all `ncy` are nil (so no reference rows), should not blow up and should return input
+  ;; dataset (including any other columns - here :row-id) with add nil `ncy-imputation` column added.
+  (def test-impute-01-ds
+    (-> (tc/concat (tc/dataset {:id  1 :calendar-year [2000 2001 2002] :academic-year      nil     })
+                   (tc/dataset {:id  2 :calendar-year [2000 2001 2002] :academic-year      nil     }))
+        (tc/add-column :row-id (range))))
+  (impute-nil-ncy test-impute-01-ds)
+                                        ;=>>
+  (tc/add-column test-impute-01-ds :academic-year-imputation nil)
 
-(rcf/tests
- "Rows with non-nil `ncy` should be returned as is save for addition
-of nil `ncy-imputation` column, regardless of other rows with nil `ncy`."
- (let [test-ds (-> (tc/concat (tc/dataset {:id  2 :calendar-year [2000 2001 2002] :academic-year [  0   1   2]})
-                              (tc/dataset {:id  3 :calendar-year [2000 2001 2002] :academic-year [  0 nil nil]})
-                              (tc/dataset {:id  4 :calendar-year [2000 2001 2002] :academic-year [nil   1 nil]})
-                              (tc/dataset {:id  5 :calendar-year [2000 2001 2002] :academic-year [nil nil   2]})
-                              (tc/dataset {:id  6 :calendar-year [2000 2001 2002] :academic-year [  0   1 nil]})
-                              (tc/dataset {:id  7 :calendar-year [2000 2001 2002] :academic-year [nil   1   2]})
-                              (tc/dataset {:id  8 :calendar-year [2000 2001 2002] :academic-year [nil  -4 nil]})
-                              (tc/dataset {:id  9 :calendar-year [2000 2001 2002] :academic-year [nil  20 nil]}))
-                   (tc/add-column :row-id (range))
-                   (tc/reorder-columns [:row-id]))
-       test-rows (into (sorted-set) ((tc/drop-missing test-ds [:academic-year]) :row-id))]
-   (-> test-ds
-       (impute-nil-ncy)
-       (tc/select-rows #(test-rows (:row-id %)))
-       (tc/order-by [:row-id]))
-   :=
-   (-> test-ds
-       (tc/select-rows test-rows)
-       (tc/select-rows #(test-rows (:row-id %)))
-       (tc/add-column :academic-year-imputation nil))))
 
-(rcf/tests
- "For a CYP with a reference row (with non-nil `ncy`), should impute
- `ncy` for any rows with nil `ncy`, otherwise leave as is.
-  NOTE: Ignoring `ncy-imputation` column for the moment"
- (-> (tc/concat (tc/dataset {:id  3 :calendar-year [2000 2001 2002] :academic-year [  0 nil nil]})
-                (tc/dataset {:id  4 :calendar-year [2000 2001 2002] :academic-year [nil   1 nil]})
-                (tc/dataset {:id  5 :calendar-year [2000 2001 2002] :academic-year [nil nil   2]})
-                (tc/dataset {:id  6 :calendar-year [2000 2001 2002] :academic-year [  0   1 nil]})
-                (tc/dataset {:id  7 :calendar-year [2000 2001 2002] :academic-year [nil   1   2]}))
-     (impute-nil-ncy)
-     (tc/drop-columns :academic-year-imputation)
-     (tc/order-by [:id :calendar-year])) :=
- (-> (tc/concat (tc/dataset {:id  3 :calendar-year [2000 2001 2002] :academic-year [  0   1   2]})
-                (tc/dataset {:id  4 :calendar-year [2000 2001 2002] :academic-year [  0   1   2]})
-                (tc/dataset {:id  5 :calendar-year [2000 2001 2002] :academic-year [  0   1   2]})
-                (tc/dataset {:id  6 :calendar-year [2000 2001 2002] :academic-year [  0   1   2]})
-                (tc/dataset {:id  7 :calendar-year [2000 2001 2002] :academic-year [  0   1   2]}))))
+  ;; "Rows with non-nil `ncy` should be returned as is save for addition of nil `ncy-imputation` column, regardless of other rows with nil `ncy`."
+  (def test-impute-02-ds
+    (-> (tc/concat (tc/dataset {:id  3 :calendar-year [2000 2001 2002] :academic-year [  0   1   2]})
+                   (tc/dataset {:id  4 :calendar-year [2000 2001 2002] :academic-year [  0 nil nil]})
+                   (tc/dataset {:id  5 :calendar-year [2000 2001 2002] :academic-year [nil   1 nil]})
+                   (tc/dataset {:id  6 :calendar-year [2000 2001 2002] :academic-year [nil nil   2]})
+                   (tc/dataset {:id  7 :calendar-year [2000 2001 2002] :academic-year [  0   1 nil]})
+                   (tc/dataset {:id  8 :calendar-year [2000 2001 2002] :academic-year [nil   1   2]})
+                   (tc/dataset {:id  9 :calendar-year [2000 2001 2002] :academic-year [nil  -4 nil]})
+                   (tc/dataset {:id 10 :calendar-year [2000 2001 2002] :academic-year [nil  20 nil]}))
+        (tc/add-column :row-id (range))
+        (tc/reorder-columns [:row-id])))
+  (def test-impute-02-rows
+    (into (sorted-set) ((tc/drop-missing test-impute-02-ds [:academic-year]) :row-id)))
+  (-> test-impute-02-ds
+      (impute-nil-ncy)
+      (tc/select-rows #(test-impute-02-rows (:row-id %)))
+      (tc/order-by [:row-id]))
+                                        ;=>>
+  (-> test-impute-02-ds
+      (tc/select-rows #(test-impute-02-rows (:row-id %)))
+      (tc/add-column :academic-year-imputation nil))
 
-(rcf/tests
- "Note that `ncy` may be imputed outside the SEND range of -4 to 20"
- (-> (tc/concat (tc/dataset {:id  8 :calendar-year [2000 2001 2002] :academic-year [nil  -4 nil]})
-                (tc/dataset {:id  9 :calendar-year [2000 2001 2002] :academic-year [nil  20 nil]}))
-     (impute-nil-ncy)
-     (tc/drop-columns :academic-year-imputation)
-     (tc/order-by [:id :calendar-year])) :=
- (-> (tc/concat (tc/dataset {:id  8 :calendar-year [2000 2001 2002] :academic-year [ -5  -4  -3]})
-                (tc/dataset {:id  9 :calendar-year [2000 2001 2002] :academic-year [ 19  20  21]}))))
 
-(rcf/tests
- "Where imputation occurs the source should be described in the `:academic-year-imputation` column"
- (-> (tc/dataset {:id 10 :calendar-year [2000 2001] :academic-year [nil   1]})
-     (impute-nil-ncy)) :=
- (-> (tc/dataset {:id 10 :calendar-year [2000 2001] :academic-year [  0   1]
-                  :academic-year-imputation [{:from-calendar-year 2001
-                                              :from-academic-year 1}
-                                             nil]})))
+  ;; For a CYP with a reference row (with non-nil `ncy`), should impute `ncy` for any rows with nil `ncy`, otherwise leave as is.
+  ;; NOTE: Ignoring `ncy-imputation` column for the moment.
+  (-> (tc/concat (tc/dataset {:id  4 :calendar-year [2000 2001 2002] :academic-year [  0 nil nil]})
+                 (tc/dataset {:id  5 :calendar-year [2000 2001 2002] :academic-year [nil   1 nil]})
+                 (tc/dataset {:id  6 :calendar-year [2000 2001 2002] :academic-year [nil nil   2]})
+                 (tc/dataset {:id  7 :calendar-year [2000 2001 2002] :academic-year [  0   1 nil]})
+                 (tc/dataset {:id  8 :calendar-year [2000 2001 2002] :academic-year [nil   1   2]}))
+      (impute-nil-ncy)
+      (tc/drop-columns :academic-year-imputation)
+      (tc/order-by [:id :calendar-year]))
+                                        ;=>>
+  (-> (tc/concat (tc/dataset {:id  4 :calendar-year [2000 2001 2002] :academic-year [  0   1   2]})
+                 (tc/dataset {:id  5 :calendar-year [2000 2001 2002] :academic-year [  0   1   2]})
+                 (tc/dataset {:id  6 :calendar-year [2000 2001 2002] :academic-year [  0   1   2]})
+                 (tc/dataset {:id  7 :calendar-year [2000 2001 2002] :academic-year [  0   1   2]})
+                 (tc/dataset {:id  8 :calendar-year [2000 2001 2002] :academic-year [  0   1   2]})))
 
-(rcf/tests
- "Where column names are specified they should be used, including
- specification of a separate column for the NCY after imputation."
- (-> (tc/dataset {:id 12 :cy [2000 2001] :ncy [nil   1]})
-     (impute-nil-ncy {:cy :cy :ncy :ncy
-                      :ncy-imputed :ncyi :ncy-imputation :ncyi-desc :imputation-from-cy :from-cy :imputation-from-ncy :from-ncy})) :=
- (-> (tc/dataset {:id 12 :cy [2000 2001] :ncy [nil   1]  :ncyi [  0   1] :ncyi-desc [{:from-cy 2001 :from-ncy 1} nil]})))
 
-(rcf/tests
- "Should also be able to specify options as keyword parameters (rather than a map)."
- (-> (tc/dataset {:id 12 :cy [2000 2001] :ncy [nil   1]})
-     (impute-nil-ncy :cy :cy :ncy :ncy
-                     :ncy-imputed :ncyi :ncy-imputation :ncyi-desc :imputation-from-cy :from-cy :imputation-from-ncy :from-ncy)) :=
- (-> (tc/dataset {:id 12 :cy [2000 2001] :ncy [nil   1]  :ncyi [  0   1] :ncyi-desc [{:from-cy 2001 :from-ncy 1} nil]})))
+  ;; Note that `ncy` may be imputed outside the SEND range of -4 to 20.
+  (-> (tc/concat (tc/dataset {:id  9 :calendar-year [2000 2001 2002] :academic-year [nil  -4 nil]})
+                 (tc/dataset {:id 10 :calendar-year [2000 2001 2002] :academic-year [nil  20 nil]}))
+      (impute-nil-ncy)
+      (tc/drop-columns :academic-year-imputation)
+      (tc/order-by [:id :calendar-year]))
+                                        ;=>>
+  (-> (tc/concat (tc/dataset {:id  9 :calendar-year [2000 2001 2002] :academic-year [ -5  -4  -3]})
+                 (tc/dataset {:id 10 :calendar-year [2000 2001 2002] :academic-year [ 19  20  21]})))
 
-(rcf/tests
- "The algorithm should work with non-keyword column & key names"
- (-> (tc/dataset {'id 13 "SEN2 census year" [2000 2001] 'NCY [nil   1]})
-     (impute-nil-ncy :id 'id :cy "SEN2 census year" :ncy 'NCY
-                     :ncy-imputed 'NCY :ncy-imputation 'ncy-imputation-desc :imputation-from-cy 'from-cy :imputation-from-ncy "from NCY")) :=
- (-> (tc/dataset {'id 13 "SEN2 census year" [2000 2001] 'NCY [  0   1] 'ncy-imputation-desc [{'from-cy 2001 "from NCY" 1} nil]})))
 
-(rcf/tests
- "With multiple possible ref. records, the one with lowest census/calendar-year should be used (:id 21 & 22).
-  If there are multiple such records, then the one with smallest NCY is chosen (:id 23).
-  Note that if pupils do not progress at a rate of one NCY per census/calendar-year then this can result in
-  discontinuities if a CYP repeats or goes back a NCY and has missing NCY in subsequent years (:id 24 & 25)."
- (-> (tc/concat (tc/dataset {:id 21 :cy [2000 2001      2002] :ncy [nil   1       2]})
-                (tc/dataset {:id 22 :cy [2000 2001      2002] :ncy [nil   1       1]})
-                (tc/dataset {:id 23 :cy [2000 2001 2001     ] :ncy [nil   1   0    ]})
-                (tc/dataset {:id 24 :cy [2000 2001      2002] :ncy [  1   1     nil]})
-                (tc/dataset {:id 25 :cy [2000 2001      2002] :ncy [  1   0     nil]}))
-     (impute-nil-ncy :cy :cy :ncy :ncy :ncy-imputed :ncy
-                     :ncy-imputation :ncy-imputation :imputation-from-cy :from-cy :imputation-from-ncy :from-ncy)) :=
- (-> (tc/concat (tc/dataset {:id 21 :cy [2000 2001      2002] :ncy [  0   1       2] :ncy-imputation [{:from-cy 2001 :from-ncy 1} nil nil]})
-                (tc/dataset {:id 22 :cy [2000 2001      2002] :ncy [  0   1       1] :ncy-imputation [{:from-cy 2001 :from-ncy 1} nil nil]})
-                (tc/dataset {:id 23 :cy [2000 2001 2001     ] :ncy [ -1   1   0    ] :ncy-imputation [{:from-cy 2001 :from-ncy 0} nil nil]})
-                (tc/dataset {:id 24 :cy [2000 2001      2002] :ncy [  1   1       3] :ncy-imputation [nil nil {:from-cy 2000 :from-ncy 1}]})
-                (tc/dataset {:id 25 :cy [2000 2001      2002] :ncy [  1   0       3] :ncy-imputation [nil nil {:from-cy 2000 :from-ncy 1}]}))))
+  ;; Where imputation occurs the source should be described in the `:academic-year-imputation` column.
+  (-> (tc/dataset {:id 11 :calendar-year [2000 2001] :academic-year [nil   1]})
+      (impute-nil-ncy))
+                                        ;=>>
+  (-> (tc/dataset {:id 11 :calendar-year [2000 2001] :academic-year [  0   1]
+                   :academic-year-imputation [{:from-calendar-year 2001 :from-academic-year 1} nil]}))
+
+
+  ;; Where column names are specified they should be used, including specification of a separate column for the NCY after imputation.
+  (-> (tc/dataset {:id 12 :cy [2000 2001] :ncy [nil   1]})
+      (impute-nil-ncy {:cy :cy :ncy :ncy
+                       :ncy-imputed :ncyi :ncy-imputation :ncyi-desc :imputation-from-cy :from-cy :imputation-from-ncy :from-ncy}))
+                                        ;=>>
+  (-> (tc/dataset {:id 12 :cy [2000 2001] :ncy [nil   1]  :ncyi [  0   1] :ncyi-desc [{:from-cy 2001 :from-ncy 1} nil]}))
+
+
+  ;; Should also be able to specify options as keyword parameters (rather than a map).
+  (-> (tc/dataset {:id 12 :cy [2000 2001] :ncy [nil   1]})
+      (impute-nil-ncy :cy :cy :ncy :ncy
+                      :ncy-imputed :ncyi :ncy-imputation :ncyi-desc :imputation-from-cy :from-cy :imputation-from-ncy :from-ncy))
+                                        ;=>>
+  (-> (tc/dataset {:id 12 :cy [2000 2001] :ncy [nil   1]  :ncyi [  0   1] :ncyi-desc [{:from-cy 2001 :from-ncy 1} nil]}))
+
+
+  ;; The algorithm should work with non-keyword column & key names.
+  (-> (tc/dataset {'id 13 "SEN2 census year" [2000 2001] 'NCY [nil   1]})
+      (impute-nil-ncy :id 'id :cy "SEN2 census year" :ncy 'NCY
+                      :ncy-imputed 'NCY :ncy-imputation 'ncy-imputation-desc :imputation-from-cy 'from-cy :imputation-from-ncy "from NCY"))
+                                        ;=>>
+  (-> (tc/dataset {'id 13 "SEN2 census year" [2000 2001] 'NCY [  0   1] 'ncy-imputation-desc [{'from-cy 2001 "from NCY" 1} nil]}))
+
+
+  ;; With multiple possible ref. records, the one with lowest census/calendar-year should be used (:id 14 & 15).
+  ;; If there are multiple such records, then the one with smallest NCY is chosen (:id 16).
+  ;; Note that if pupils do not progress at a rate of one NCY per census/calendar-year then
+  ;; this can result in discontinuities if a CYP repeats or goes back a NCY and has missing NCY in subsequent years (:id 17 & 18).
+  (-> (tc/concat (tc/dataset {:id 14 :cy [2000 2001      2002] :ncy [nil   1       2]})
+                 (tc/dataset {:id 15 :cy [2000 2001      2002] :ncy [nil   1       1]})
+                 (tc/dataset {:id 16 :cy [2000 2001 2001     ] :ncy [nil   1   0    ]})
+                 (tc/dataset {:id 17 :cy [2000 2001      2002] :ncy [  1   1     nil]})
+                 (tc/dataset {:id 18 :cy [2000 2001      2002] :ncy [  1   0     nil]}))
+      (impute-nil-ncy :cy :cy :ncy :ncy :ncy-imputed :ncy
+                      :ncy-imputation :ncy-imputation :imputation-from-cy :from-cy :imputation-from-ncy :from-ncy))
+                                        ;=>>
+  (-> (tc/concat (tc/dataset {:id 14 :cy [2000 2001      2002] :ncy [  0   1       2] :ncy-imputation [{:from-cy 2001 :from-ncy 1} nil nil]})
+                 (tc/dataset {:id 15 :cy [2000 2001      2002] :ncy [  0   1       1] :ncy-imputation [{:from-cy 2001 :from-ncy 1} nil nil]})
+                 (tc/dataset {:id 16 :cy [2000 2001 2001     ] :ncy [ -1   1   0    ] :ncy-imputation [{:from-cy 2001 :from-ncy 0} nil nil]})
+                 (tc/dataset {:id 17 :cy [2000 2001      2002] :ncy [  1   1       3] :ncy-imputation [nil nil {:from-cy 2000 :from-ncy 1}]})
+                 (tc/dataset {:id 18 :cy [2000 2001      2002] :ncy [  1   0       3] :ncy-imputation [nil nil {:from-cy 2000 :from-ncy 1}]})))
+  )


### PR DESCRIPTION
- Replace hyperfiddle.rcf tests with com.mjdowney.rich-comment-tests.
- Refactor rcf tests that used `let`.
- Add function to calculate age prior to start of school year.