### PR TITLE
Reorder `color-and-shape-lookup`

### DIFF
--- a/src/witan/send/adroddiad/clerk/charting_v2.clj
+++ b/src/witan/send/adroddiad/clerk/charting_v2.clj
@@ -13,9 +13,9 @@
 (def full-width 1420)
 
 (defn color-and-shape-lookup [domain]
-  ;; Using Tableau 20 palette ordered with Tableau 10 shades first,
-  ;; then the lighter shades in the same order.
-  ;; With 20 colours and 8 shaps, this gives 40 distinct combinations.
+  ;; Using Tableau 20 palette, excluding the red, ordered with
+  ;; Tableau 10 shades first, then the lighter shades in the same order.
+  ;; With 19 colours and 8 shapes, this gives 152 distinct combinations.
   (tc/dataset
    {:domain-value domain
     ;; I’d like to eventually do something based on these colours in v3
@@ -25,7 +25,7 @@
                         [ 31 119 180 255]
                         [255 127  14 255]
                         [ 44 160  44 255]
-                        [214  39  40 255]
+                        #_[214  39  40 255]
                         [148 103 189 255]
                         [140  86  75 255]
                         [227 119 194 255]

--- a/src/witan/send/adroddiad/clerk/charting_v2.clj
+++ b/src/witan/send/adroddiad/clerk/charting_v2.clj
@@ -13,17 +13,44 @@
 (def full-width 1420)
 
 (defn color-and-shape-lookup [domain]
+  ;; Using Tableau 20 palette ordered with Tableau 10 shades first,
+  ;; then the lighter shades in the same order.
+  ;; With 20 colours and 8 shaps, this gives 40 distinct combinations.
   (tc/dataset
    {:domain-value domain
-    :color (cycle
-            ;; I’d like to eventually do something based on these colours in v3
-            ;; ["#fa814c" "#256cc6" "#fbe44c" "#50b938" "#59c4b8" "#29733c"]
-            (into []
-                  (map color/format-hex)
-                  (color/palette :tableau-20)))
-    :shape (cycle ["circle", "square", "cross", "diamond", "triangle-up", "triangle-down", "triangle-right", "triangle-left"])}))
-
-
+    ;; I’d like to eventually do something based on these colours in v3
+    ;; ["#fa814c" "#256cc6" "#fbe44c" "#50b938" "#59c4b8" "#29733c"]
+    :color (cycle (map color/format-hex
+                       [;; tableau 10
+                        [ 31 119 180 255]
+                        [255 127  14 255]
+                        [ 44 160  44 255]
+                        [214  39  40 255]
+                        [148 103 189 255]
+                        [140  86  75 255]
+                        [227 119 194 255]
+                        [127 127 127 255]
+                        [188 189  34 255]
+                        [ 23 190 207 255]
+                        ;; tableau 20 lighter shades
+                        [174 199 232 255]
+                        [255 187 120 255]
+                        [152 223 138 255]
+                        [255 152 150 255]
+                        [197 176 213 255]
+                        [196 156 148 255]
+                        [247 182 210 255]
+                        [199 199 199 255]
+                        [219 219 141 255]
+                        [158 218 229 255]]))
+    :shape (cycle ["circle"
+                   "square"
+                   "triangle-up"
+                   "triangle-down"
+                   "triangle-right"
+                   "triangle-left"
+                   "cross"
+                   "diamond"])}))
 
 (defn color-map [plot-data color-field color-lookup]
   (let [group-keys (into (sorted-set) (get plot-data color-field))


### PR DESCRIPTION
Update color-and-shape-lookup to avoid having light orange squares next to orange crosses, and to drop the angry red:
- Remove red from the Tableau 20 colours.
- Reorder the remaining Tableau 20 colours to put the Tableau 10 colours first and then the lighter shades in the same order.
- Reorder the shapes to move "cross" from 3rd to 8th position, so using triangles in preference, to avoid confusion with "circle" and "square" with small (<8) numbers of lines.

Dropping one of the 20 colours also has the advantage of having a prime number of colours, such that the number of distinct colours and shapes is 152.