### PR TITLE
remove tooltip helper fn

### DIFF
--- a/src/witan/send/adroddiad/clerk/charting_v2.clj
+++ b/src/witan/send/adroddiad/clerk/charting_v2.clj
@@ -819,3 +819,19 @@
                           :color-field     color-field
                           :title           (str "# EHCPs per Designation by Primary Need in " year)
                           :white-text-test white-text-test}))))) [2022 2023])))
+
+(defn remove-tooltips [chart]
+  (assoc chart :layer
+         [(-> chart
+              :layer
+              second
+              (dissoc :encoding)
+              (assoc-in [:mark :strokeWidth] 0))
+          (-> chart
+              :layer
+              first
+              (assoc :layer
+                     (remove #(contains? % :transform) (-> chart
+                                                           :layer
+                                                           first
+                                                           :layer))))]))


### PR DESCRIPTION
This felt like the most general place to put this fn as multiple namespaces in the analysis sub-dir create charts which need the tooltips removing when outputting to png