### PR TITLE
Need and school phase definitions for reporting

### DIFF
--- a/src/witan/send/adroddiad/need.clj
+++ b/src/witan/send/adroddiad/need.clj
@@ -1,0 +1,100 @@
+(ns witan.send.adroddiad.need
+  "Definitions and functions for handling EHCP needs."
+  (:require [tablecloth.api :as tc]))
+
+
+
+;;; # Utility functions
+(defn compare-mapped-keys
+  [m k1 k2]
+  (compare [(get m k1) k1]
+           [(get m k2) k2]))
+
+
+
+;;; # Needs
+(def needs
+  "EHCP need definitions."
+  (as-> {
+         "ASD"  {:order      1
+                 :name       "Autistic Spectrum Disorder"
+                 :label      "ASD"
+                 :definition "Autistic spectrum disorder"
+                 :sen2-order 11
+                 :send-area  "CnI"}
+         "SLCN" {:order      2
+                 :name       "Speech, Language and Communication Needs"
+                 :label      "SLCN"
+                 :definition "Speech, language and communication needs"
+                 :sen2-order 6
+                 :send-area  "CnI"}
+         "SEMH" {:order      3
+                 :name       "Social, Emotional and Mental Health"
+                 :label      "SEMH"
+                 :definition "Social, emotional and mental health"
+                 :sen2-order 5
+                 :send-area  "SEM"}
+         "SPLD" {:order      4
+                 :name       "Specific Learning Difficulty"
+                 :label      "SpLD"     ; Note lower case "p"
+                 :definition "Specific learning difficulty"
+                 :sen2-order 1
+                 :send-area  "CnL"}
+         "MLD"  {:order      5
+                 :name       "Moderate Learning Difficulty"
+                 :label      "MLD"
+                 :definition "Moderate learning difficulty"
+                 :sen2-order 2
+                 :send-area  "CnL"}
+         "SLD"  {:order      6
+                 :name       "Severe Learning Difficulty"
+                 :label      "SLD"
+                 :definition "Severe learning difficulty"
+                 :sen2-order 3
+                 :send-area  "CnL"}
+         "PMLD" {:order      7
+                 :name       "Profound and Multiple Learning Difficulty"
+                 :label      "PMLD"
+                 :definition "Profound and multiple learning difficulty"
+                 :sen2-order 4
+                 :send-area  "CnL"}
+         "HI"   {:order      8
+                 :name       "Hearing Impairment"
+                 :label      "HI"
+                 :definition "Hearing impairment"
+                 :sen2-order 7
+                 :send-area  "SPN"}
+         "VI"   {:order      9
+                 :name       "Vision Impairment"
+                 :label      "VI"
+                 :definition "Vision impairment"
+                 :sen2-order 8
+                 :send-area  "SPN"}
+         "MSI"  {:order      10
+                 :name       "Multi-Sensory Impairment"
+                 :label      "MSI"
+                 :definition "Multi-sensory impairment"
+                 :sen2-order 9
+                 :send-area  "SPN"}
+         "PD"   {:order      11
+                 :name       "Physical Disability"
+                 :label      "PD"
+                 :definition "Physical disability"
+                 :sen2-order 10
+                 :send-area  "SPN"}
+         "OTH"  {:order      12
+                 :name       "Other Difficulty"
+                 :label      "OTH"
+                 :definition "Other difficulty"
+                 :sen2-order 12
+                 :send-area  "OTH"}} $
+    (into (sorted-map-by (partial compare-mapped-keys (update-vals $ :order))) $)))
+
+(def needs-ds
+  "EHCP need definitions as a dataset."
+  (as-> needs $
+    (map (fn [[k v]] (assoc v :abbreviation k)) $)
+    (tc/dataset $)
+    (tc/reorder-columns $ [:abbreviation])
+    (tc/set-dataset-name $ "needs")))
+

--- a/src/witan/send/adroddiad/school_phase.clj
+++ b/src/witan/send/adroddiad/school_phase.clj
@@ -26,15 +26,16 @@
 
 ;;; # Mastodon C School Phases
 ;; Note that in contrast to school phases previously defined in `witan.send.domain.academic-years`:
-;; - using "early-childhood" for NCYs #{-4 -3 -2 -1} (as recommended by our advisor 11-AUG-22),
+;; - Using "early-childhood" for NCYs #{-4 -3 -2 -1} (as recommended by our advisor 11-NOV-22),
 ;;   rather than "nursery" or "early-years" to avoid confusion:
 ;;   - Nursery schools are "aimed at pre-school children aged three and four years old"
 ;;     (according to the [Early Years Alliance](https://www.eyalliance.org.uk/how-choose-right-childcare-and-early-education)).
 ;;   - Early years as used in [national curriculum](https://www.gov.uk/national-curriculum) is NCYs #{-1 0}.
 ;;   - Early years as used in [early years foundation stage (EYFS)](https://www.gov.uk/early-years-foundation-stage)
 ;;     is "from birth to 5 years old" which includes reception.
-;; - keys are abbreviations rather than keywords, to facilitate use in datasets & files as strings
-;; - abbreviations are hyphenated so "keyword friendly" and can be converted to keywords if required
+;; - Keys are abbreviations rather than keywords, to facilitate use in datasets & files as strings.
+;; - Abbreviations are hyphenated so "keyword friendly" and can be converted to keywords if required.
+;; - The map is sorted so that `(keys school-phases)` returns the school phases in the correct order.
 
 (def school-phases
   "Mastodon C School Phase definitions as a sorted map."

--- a/src/witan/send/adroddiad/school_phase.clj
+++ b/src/witan/send/adroddiad/school_phase.clj
@@ -1,0 +1,96 @@
+(ns witan.send.adroddiad.school-phase
+  "Definitions and functions for handling Mastodon C's definitions of school phase for SEND reporting and planning:
+   Note that:
+   - early-childhood is everything before starting school in reception
+   - primary         includes reception
+   - secondary       ends at NCY 11 (age 15-16), and excludes sixth-form
+   - education after secondary is split into post-16 and post-19,
+     where the ages 16 & 19 indicated are the nominal ages for the NCYs included†, and are inclusive:
+     - post-16: NCYs 12–14 (corresponding to ages 16–18 at start of NCY†)
+     - post-19: NCYs 15–20 (corresponding to ages 18–24 at start of NCY†)
+     …with post-16 being 3 years (rather than the 2 of a sixth-form)
+      matching the right of CYP to 3 years of post secondary education.
+
+   † Where ages are given, these relate to the nominal NCY for the age on 31st August prior to the start of the school year.
+     (For details and mapping of age to nominal NCY, see `witan.send.adroddiad.ncy`.)"
+  (:require [tablecloth.api :as tc]))
+
+
+
+;;; # Utility functions
+(defn compare-mapped-keys
+  [m k1 k2]
+  (compare [(get m k1) k1]
+           [(get m k2) k2]))
+
+
+;;; # Mastodon C School Phases
+;; Note that in contrast to school phases previously defined in `witan.send.domain.academic-years`:
+;; - using "early-childhood" for NCYs #{-4 -3 -2 -1} (as recommended by our advisor 11-AUG-22),
+;;   rather than "nursery" or "early-years" to avoid confusion:
+;;   - Nursery schools are "aimed at pre-school children aged three and four years old"
+;;     (according to the [Early Years Alliance](https://www.eyalliance.org.uk/how-choose-right-childcare-and-early-education)).
+;;   - Early years as used in [national curriculum](https://www.gov.uk/national-curriculum) is NCYs #{-1 0}.
+;;   - Early years as used in [early years foundation stage (EYFS)](https://www.gov.uk/early-years-foundation-stage)
+;;     is "from birth to 5 years old" which includes reception.
+;; - keys are abbreviations rather than keywords, to facilitate use in datasets & files as strings
+;; - abbreviations are hyphenated so "keyword friendly" and can be converted to keywords if required
+
+(def school-phases
+  "Mastodon C School Phase definitions as a sorted map."
+  (as-> {"early-childhood" {:order      0
+                            :name       "Early Childhood Education and Care"
+                            :label      "Early Childhood"
+                            :definition "Prior to starting school: Age 0-4"
+                            :ncy-from   -4 ;; Note witan.send.domain.academic-years/nursery includes -5
+                            :ncy-to     -1}
+         "primary"         {:order      1
+                            :name       "Primary"
+                            :label      "Primary"
+                            :definition "Primary school: Reception, KS1 & KS2 - Reception + NCYs 1 to 6"
+                            :ncy-from   0
+                            :ncy-to     6}
+         "secondary"       {:order      2
+                            :name       "Secondary"
+                            :label      "Secondary"
+                            :definition "Secondary school: Key Stages 3 + 4 - NCYs 7 to 11"
+                            :ncy-from   7
+                            :ncy-to     11}
+         "post-16"         {:order      3
+                            :name       "Post 16"
+                            :label      "Post 16"
+                            :definition "Post 16 - Key Stage 5 - NCYs 12 to 14"
+                            :ncy-from   12
+                            :ncy-to     14}
+         "post-19"         {:order      4
+                            :name       "Post 19"
+                            :label      "Post 19"
+                            :definition "Post 19 - Post Key Stage 5 up to 25 years of age - NCYs 15 to 20"
+                            :ncy-from   15
+                            :ncy-to     20}} $
+    (update-vals $ (fn [m] (assoc m :ncys (into (sorted-set) (range (:ncy-from m) (inc (:ncy-to m)))))))
+    (into (sorted-map-by (partial compare-mapped-keys (update-vals $ :order))) $)))
+
+(def school-phases-ds
+  "Mastodon C School Phase definitions as a dataset."
+  (as-> school-phases $
+    (map (fn [[k v]] (assoc v :abbreviation k)) $)
+    (tc/dataset $)
+    (tc/reorder-columns $ [:abbreviation])
+    (tc/set-dataset-name $ "school-phases")))
+
+
+
+;;; # Functions to manipulate school-phases
+(defn ncy->school-phase
+  "Given National Curriculum Year `x` and [optional] map of `school-phases`,
+   returns the abbreviation for the MC School Phase containing it.
+  `school-phases` must be a map with keys the school phase
+   and values maps containing a `:ncys` key whose value is a collection of the NCYs for that school phase.
+   Defaults to the namespace `school-phase` if not specified."
+  ([x] (ncy->school-phase x school-phases))
+  ([x school-phases]
+   (some (fn [[k {:keys [ncys]}]]
+           (when (contains? ncys x) k))
+         school-phases)))
+

--- a/test/witan/send/adroddiad/school_phase_test.clj
+++ b/test/witan/send/adroddiad/school_phase_test.clj
@@ -1,0 +1,39 @@
+(ns witan.send.adroddiad.school-phase-test
+  (:require [clojure.test :refer [deftest testing is]]
+            [witan.send.adroddiad.school-phase :as school-phase]))
+
+(deftest ncy->school-phase
+  (testing "For NCY not in (range -4 (inc 20)), school-phase should be nil."
+    (is (->> nil school-phase/ncy->school-phase nil?))
+    (is (->>  -5 school-phase/ncy->school-phase nil?))
+    (is (->>  21 school-phase/ncy->school-phase nil?)))
+
+  (testing "For NCYs -4 to -1 school-phase should be \"early-childhood\"."
+    (is (->> [-4 -3 -2 -1]
+             (map school-phase/ncy->school-phase)
+             (every? #{"early-childhood"}))))
+
+  (testing "For NCYs 0 to 6 school-phase should be \"primary\"."
+    (is (->> [0 1 2 3 4 5 6]
+             (map school-phase/ncy->school-phase)
+             (every? #{"primary"}))))
+
+  (testing "For NCYs 7 to 11 school-phase should be \"secondary\"."
+    (is (->> [7 8 9 10 11]
+             (map school-phase/ncy->school-phase)
+             (every? #{"secondary"}))))
+
+  (testing "For NCYs 12 to 14 school-phase should be \"post-16\"."
+    (is (->> [12 13 14]
+             (map school-phase/ncy->school-phase)
+             (every? #{"post-16"}))))
+
+  (testing "For NCYs 15 to 20 school-phase should be \"post-19\"."
+    (is (->> [15 16 17 18 19 20]
+             (map school-phase/ncy->school-phase)
+             (every? #{"post-19"}))))
+  )
+
+(comment
+  (clojure.test/run-tests)
+  )


### PR DESCRIPTION
Definitions of need and school-phase in the style of witan.send.settings to facilitate consistent reporting.

Note that `school-phase` does not replicate all the functionality of `witan.send.domain.academic-years`, and uses "early-childhood" for NCYs -4 to -1.