### PR TITLE
Charting tweaks

### DIFF
--- a/src/witan/send/adroddiad/analysis/total_domain.clj
+++ b/src/witan/send/adroddiad/analysis/total_domain.clj
@@ -215,11 +215,11 @@
 ;;; All Settings
  )
 (defn total-summary-plot
-  [{:keys [data colors-and-shapes order-field label-field group-title]}]
+  [{:keys [data chart-title colors-and-shapes order-field label-field group-title]}]
   (line-and-ribbon-and-rule-plot
    {:data              (-> data
                            (tc/map-columns :calendar-year [:calendar-year] format-calendar-year))
-    :chart-title       (str "# EHCP by " (name label-field))
+    :chart-title       (or chart-title (str "# EHCP by " (or group-title (name label-field))))
     :chart-height      vs/full-height :chart-width vs/two-thirds-width
     :tooltip-formatf   (vsl/number-summary-tooltip {:group label-field :x :calendar-year :tooltip-field :tooltip-column})
     :colors-and-shapes colors-and-shapes
@@ -273,6 +273,3 @@
   [{}]
   )
 
-(
-;;; Each Setting on its own
- )

--- a/src/witan/send/adroddiad/clerk/charting_v2.clj
+++ b/src/witan/send/adroddiad/clerk/charting_v2.clj
@@ -821,18 +821,4 @@
                           :title           (str "# EHCPs per Designation by Primary Need in " year)
                           :white-text-test white-text-test}))))) [2022 2023])))
 
-(defn remove-tooltips [chart]
-  (assoc chart :layer
-         [(-> chart
-              :layer
-              second
-              (dissoc :encoding)
-              (assoc-in [:mark :strokeWidth] 0))
-          (-> chart
-              :layer
-              first
-              (assoc :layer
-                     (remove #(contains? % :transform) (-> chart
-                                                           :layer
-                                                           first
-                                                           :layer))))]))
+

--- a/src/witan/send/adroddiad/vega_specs/lines.clj
+++ b/src/witan/send/adroddiad/vega_specs/lines.clj
@@ -293,3 +293,19 @@
                             :color   (assoc (vs/color-map data group colors-and-shapes) :title group-title)
                             :shape   (vs/shape-map data group colors-and-shapes)
                             :tooltip tooltip}}]}))
+
+(defn remove-tooltips [chart]
+  (assoc chart :layer
+         [(-> chart
+              :layer
+              second
+              (dissoc :encoding)
+              (assoc-in [:mark :strokeWidth] 0))
+          (-> chart
+              :layer
+              first
+              (assoc :layer
+                     (remove #(contains? % :transform) (-> chart
+                                                           :layer
+                                                           first
+                                                           :layer))))]))


### PR DESCRIPTION
Charting tweaks:
- move `remove-tooltips` to the namespace with the `line-and-ribbon-and-rule-plot` that creates the tooltips that need removing.
- allow more flexible specification of chart title.