### PR TITLE
Expand options for file names and locations in witan.send.adroddiad.clerk.html

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -11,13 +11,13 @@
  :aliases
  {:dev  {:extra-paths ["notebooks" "dev" "test"]
          :extra-deps  {org.clojure/clojure         {:mvn/version "1.11.1"}
-                       io.github.nextjournal/clerk {:mvn/version "0.15.957"}
+                       io.github.nextjournal/clerk {:mvn/version "0.16.1016"}
                        scicloj/tablecloth          {:mvn/version "7.014"
                                                     :exclusions  [techascent/tech.ml.dataset]}
                        techascent/tech.ml.dataset  {:mvn/version "7.019"}
                        nextjournal/clerk-slideshow
                        {:git/url    "https://github.com/nextjournal/clerk-slideshow"
-                        :git/sha    "977003e581d78f4f554bb8ae73f877f4070925c3"
+                        :git/sha    "f9fb86430ebf533bfc9d5cec5bf0a94ed07146f3"
                         :exclusions [techascent/tech.ml.dataset io.github.nextjournal/clerk]}}}
   :test {:extra-paths ["test"]
          :extra-deps  {org.clojure/test.check {:mvn/version "1.1.0"}}}}}

--- a/src/witan/send/adroddiad/clerk/html.clj
+++ b/src/witan/send/adroddiad/clerk/html.clj
@@ -4,6 +4,52 @@
    [clojure.string :as str]
    [nextjournal.clerk :as clerk]))
 
+(defn ns->filepath
+  "Given a namespace (name) `ns` and (optional) `project-path`
+   (which may be specified without a trailing \"/\" as in `deps.edn`),
+   returns the path (relative to its project root) of the corresponding `*.clj` file,
+   by replacing . with / & - with _. and prepending the `project-path`."
+  [ns project-path]
+  (str project-path
+       (if (str/ends-with? project-path "/") nil "/")
+       (str/replace ns #"\.|-" {"." "/", "-" "_"})
+       ".clj"))
+
+(defn build-ns!
+  "Build static HTML file from \"*.clj\" file corresponding to namespace (named) `ns`.
+   Optional trailing keyword arguments specify:
+   - `project-path`: the path (relative to the project root) under which
+                     the namespace \"*.clj\" file resides..
+                     (May be specified without a trailing \"/\" as in `deps.edn`.)
+                     Defaults to \"notebooks\".
+   - `out-dir`     : the path under which the built HTML should be saved.
+                     (May be specified without a trailing \"/\".)
+                     Defaults to the directory containing the namespace \"*.clj\" file.
+   - `out-filename`: the filename (relative to `out-dir`) for the HTML file.
+                     (May be specified without the \".html\" extension.)
+                     (May be specified with leading sub-directories.)
+                     Defaults to the last component of the namespace name."
+  [ns & {:keys [project-path out-dir out-filename]
+         :or   {project-path "notebooks"}}]
+  (let [ns-filepath  (ns->filepath ns project-path)
+        out-dir      (or out-dir (str/replace ns-filepath #"\/[^\/]+$" "/"))
+        out-filename (or out-filename (str/replace ns #"^.*\." ""))
+        out-filepath (str out-dir
+                          (if (str/ends-with? out-dir "/") nil "/")
+                          out-filename
+                          (if (str/ends-with? out-filename ".html") nil ".html"))]
+    #_{:ns-filepath  ns-filepath
+       :out-dir      out-dir
+       :out-filename out-filename
+       :out-filepath out-filepath}
+    (io/make-parents out-filepath)
+    (clerk/build! {:paths      [ns-filepath]
+                   :ssr        true
+                   #_#_:bundle true         ; clerk v0.15.957
+                   :package    :single-file ; clerk v0.16.1016
+                   :out-path   "."})
+    (.renameTo (io/file "./index.html") (io/file out-filepath))))
+
 (defn root-ns-to-out-dir
   "Convert the first part of `ns` to a path name."
   [ns]
@@ -24,25 +70,36 @@
        (format "%s%s.html" out-dir)))
 
 (defn ns->html
-  "Output the current namespace as an html file in a directory where the
-  non-ending bits of the namespace are a file path."
+  "Build static HTML file from the \"*.clj\" file corresponding to namespace (named) `ns`,
+   saving the HTML file under `out-dir` with filepath (relative to `out-dir`) derived
+   from the namespace name turned into a path (i.e. with \".\" replaced by \"/\")."
   [out-dir ns]
-  (let [in-path   (str "notebooks/" (pathified-namespace ns) ".clj")
-        out-path  (ns-to-html-file-name out-dir ns)
-        index-out (str out-dir "index.html")]
-    (io/make-parents out-path)
-    (clerk/build! {:paths    [in-path]
-                   :ssr      true
-                   :package  :single-file
-                   :out-path out-dir})
-    (.renameTo (io/file index-out) (io/file out-path))))
+  (build-ns! ns {:out-dir      out-dir
+                 :out-filename (ns-to-html-file-name "" *ns*)}))
 
-(def out-dir (root-ns-to-out-dir *ns*))
+(comment ;;; # Example usage
+  ;; Build static HTML of current notebook namespace (assumed to be derived
+  ;; from a *.clj file in the "notebooks" project-path) and save the
+  ;; resulting HTML file alongside the *.clj with filename matching the
+  ;; leaf of the namespace name (i.e. matching the *.clj file name but with
+  ;; "_" replaced with "-"):
+  (build-ns! *ns*)
 
-(comment
+  ;; Build static HTML of current notebook namespace and save in
+  ;; "./wp-2-16-1/" (relative to the project root) with filename
+  ;; matching the leaf of the namespace name:
+  (build-ns! *ns* :out-dir "./wp-2-16-1/")
 
+  ;; Where the first part of the namespace name matches the desired output
+  ;; directory, `root-ns-to-out-dir` may be used to extract the `out-dir`:
   (def out-dir (root-ns-to-out-dir *ns*))
 
+  ;; Build static HTML of current notebook namespace and save under `out-dir`,
+  ;; with path to the HTML file relative to `out-dir` derived from the full
+  ;; namespace name turned into a path (i.e. with "." replaced with "/"):
+  (build-ns! ns {:out-dir      out-dir
+                 :out-filename (ns-to-html-file-name "" *ns*)})
+  ;; or:
   (ns->html out-dir *ns*)
 
   )

--- a/src/witan/send/adroddiad/clerk/html.clj
+++ b/src/witan/send/adroddiad/clerk/html.clj
@@ -4,15 +4,15 @@
    [clojure.string :as str]
    [nextjournal.clerk :as clerk]))
 
-(defn root-ns-to-out-dir 
+(defn root-ns-to-out-dir
   "Convert the first part of `ns` to a path name."
   [ns]
-  (->> ns 
+  (->> ns
        str
        (re-find #"^[^\.]*")
        (format "./%s/")))
 
-(defn pathified-namespace 
+(defn pathified-namespace
   "Turn . into / and - into _"
   [ns]
   (str/replace ns #"\.|-" {"." "/" "-" "_"}))
@@ -33,7 +33,7 @@
     (io/make-parents out-path)
     (clerk/build! {:paths    [in-path]
                    :ssr      true
-                   :bundle   true
+                   :package  :single-file
                    :out-path out-dir})
     (.renameTo (io/file index-out) (io/file out-path))))
 
@@ -44,5 +44,5 @@
   (def out-dir (root-ns-to-out-dir *ns*))
 
   (ns->html out-dir *ns*)
-  
+
   )


### PR DESCRIPTION
New function `build-ns!` to build clerk notebooks:
- allows (optional) specification of the ns-path (default "notebooks")
- if out-dir is not specified then defaults to write in the same folder as the ns source file
- if out-dir is specified then puts the built HTML file there rather than in sub-directories corresponding to the namespace name stem components
- allows (optional) specification of the file name for the built HTML, defaulting to the namespace name "leaf": this can be (ab)used to include leading pathname components if required.

Functionality of previous `ns->html` retained through appropriate call to new `build-ns!`.

Usage examples added.