### PR TITLE
Fix tooltips for numeric group

### DIFF
--- a/src/witan/send/adroddiad/analysis/total_domain.clj
+++ b/src/witan/send/adroddiad/analysis/total_domain.clj
@@ -221,7 +221,7 @@
                            (tc/map-columns :calendar-year [:calendar-year] format-calendar-year))
     :chart-title       (or chart-title (str "# EHCP by " (or group-title (name label-field))))
     :chart-height      vs/full-height :chart-width vs/two-thirds-width
-    :tooltip-formatf   (vsl/number-summary-tooltip {:group label-field :x :calendar-year :tooltip-field :tooltip-column})
+    :tooltip-formatf   (vsl/number-summary-tooltip {:tooltip-field :tooltip-column})
     :colors-and-shapes colors-and-shapes
     :x                 :calendar-year :x-title     "Census Year" :x-format    "%b %Y"
     :y-title           "# EHCPs"      :y-zero      true          :y-scale     false
@@ -243,7 +243,7 @@
      {:data              data
       :chart-title       (str "EHCP change Year on Year by " (name label-field))
       :chart-height      vs/full-height      :chart-width vs/two-thirds-width
-      :tooltip-formatf   (vsl/number-summary-tooltip {:group label-field :x :calendar-year :tooltip-field :tooltip-column})
+      :tooltip-formatf   (vsl/number-summary-tooltip {:tooltip-field :tooltip-column})
       :colors-and-shapes colors-and-shapes
       :x                 :calendar-year      :x-title     "Census Year" :x-format "%b %Y"
       :x-scale (mapv format-calendar-year (range (:min calendar-year-limits) (+ 1 (:max calendar-year-limits))))
@@ -261,7 +261,7 @@
      {:data              data
       :chart-title       (or chart-title (str "% EHCP change year on year by " (name label-field)))
       :chart-height      vs/full-height      :chart-width vs/two-thirds-width
-      :tooltip-formatf   (vsl/pct-summary-tooltip {:group label-field :x :calendar-year :tooltip-field :tooltip-column})
+      :tooltip-formatf   (vsl/pct-summary-tooltip {:tooltip-field :tooltip-column})
       :colors-and-shapes colors-and-shapes
       :x                 :calendar-year      :x-title     "Census Year" :x-format "%b %Y"
       :x-scale (mapv format-calendar-year (range (:min calendar-year-limits) (+ 1 (:max calendar-year-limits))))

--- a/src/witan/send/adroddiad/vega_specs/lines.clj
+++ b/src/witan/send/adroddiad/vega_specs/lines.clj
@@ -117,6 +117,11 @@
                                         tooltip-formatf
                                         (tc/order-by [x])
                                         (tc/select-columns [x group tooltip-field])
+                                        (tc/update-columns [group] (partial map (partial str " ")))
+                                        ; Ensure `group` is a string to avoid issues (seen with 0 NCY) in displayed tooltip:
+                                        ;; - string to avoid vl showing tooltip for 0 as "undefiend".
+                                        ;; - leading space to avoid vl putting digit groups before `x-title` in tooltip
+                                        ;;   (despite order in :encoding :tooltip below).
                                         (tc/pivot->wider [group] [tooltip-field] {:drop-missing? false})
                                         (tc/replace-missing :all :value "")
                                         (tc/reorder-columns (cons x (:domain-value colors-and-shapes)))
@@ -125,7 +130,7 @@
                  :encoding {:opacity {:condition {:value 0.3 :param "hover" :empty false}
                                       :value     0}
                             :tooltip (into [{:field x :type "temporal" :format x-format :title x-title}]
-                                           (map (fn [g] {:field g}))
+                                           (map (fn [g] {:field (str " " g)}))
                                            (keep (into #{} (get data group)) (get colors-and-shapes :domain-value)))}
                  :params   [{:name   "hover"
                              :select {:type    "point"


### PR DESCRIPTION
Issues addressed:
- tooltip for group 0 showing as "undefiend"
- tooltip putting the x-title at the bottom for numeric groups