### PR TITLE
Default colors and shapes

### DIFF
--- a/src/witan/send/adroddiad/vega_specs/lines.clj
+++ b/src/witan/send/adroddiad/vega_specs/lines.clj
@@ -410,24 +410,27 @@
    - passes through to a specific `plotf` to return a Vega-Lite spec.
 
    Note:
-   - Only requires: `data` `group` `colors-and-shapes`.
+   - Only requires: `data` & `group`.
    - Other parameters (except `plotf`) are passed through to `plotf`
      (overriding any defaults specified here)."
   [& {:keys [data group group-title colors-and-shapes plotf]
-      :or   {group-title nil
-             plotf       line-and-ribbon-and-rule-plot}
+      :or   {group-title       nil
+             colors-and-shapes nil
+             plotf             line-and-ribbon-and-rule-plot}
       :as   plot-spec}]
   (-> base-chart-spec
-      (merge {:chart-title  (str "#EHCPs by " (or group-title (name group)))
-              :chart-height vs/full-height
-              :chart-width  vs/two-thirds-width
-              :x            :calendar-year
-              :x-format     "%Y"
-              :x-title      "Census Year"
-              :y-title      "# EHCPs"
-              :y-zero       true
-              :y-scale      false
-              :group-title  (or group-title (name group))})
+      (merge {:chart-title       (str "#EHCPs by " (or group-title (name group)))
+              :chart-height      vs/full-height
+              :chart-width       vs/two-thirds-width
+              :x                 :calendar-year
+              :x-format          "%Y"
+              :x-title           "Census Year"
+              :y-title           "# EHCPs"
+              :y-zero            true
+              :y-scale           false
+              :group-title       (or group-title (name group))
+              :colors-and-shapes (when (nil? colors-and-shapes)
+                                   (-> data (get group) distinct vs/color-and-shape-lookup))})
       (merge plot-spec)
       plot-spec-by-group->plot-spec-by-group-label
       ((fn [m] (update m :data

--- a/src/witan/send/adroddiad/vega_specs/lines.clj
+++ b/src/witan/send/adroddiad/vega_specs/lines.clj
@@ -398,8 +398,8 @@
 
 (defn process-colors-and-shapes
   "Processes a `plot-spec` to:
-   - make a default `colors-and-shapes` (for the `group` values in the `data`) if none specified,
-   - throw an exception if supplied `:colors-and-shapes` doesn't contain all `group`s in the `data`, and
+   - provide a default `colors-and-shapes` (for the `group` values in the `data`) if none specified,
+   - throw an exception if the supplied `:colors-and-shapes` doesn't contain all `group`s in the `data`, and
    - call `plot-spec-by-group->plot-spec-by-group-label` to apply any labels in the `colors-and-shapes` to the `group` values."
   [{:keys [data group colors-and-shapes] :as plot-spec}]
   (let [data-groups                       (-> data (get group) set)
@@ -429,7 +429,7 @@
    7-number summary of #EHCP projections (y-axis) against year (x-axis) grouped
    by `group` (i.e. with a separate line for each value of `group`), then:
    - calls `process-colors-and-shapes` to:
-     - makes a default `colors-and-shapes` if not specified, and
+     - provide a default `colors-and-shapes` if none specified, and
      - apply any labels;
    - ensures the year `x` variable is a string (for vega-lite), and
    - passes through to a specific `plotf` to return a Vega-Lite spec.

--- a/src/witan/send/adroddiad/vega_specs/lines.clj
+++ b/src/witan/send/adroddiad/vega_specs/lines.clj
@@ -396,9 +396,6 @@
                             e))
                   $)))
 
-
-
-;;; # Wrappers
 (defn process-colors-and-shapes
   "Processes a `plot-spec` to:
    - make a default `colors-and-shapes` (for the `group` values in the `data`) if none specified,
@@ -422,6 +419,9 @@
       :else
       (plot-spec-by-group->plot-spec-by-group-label plot-spec))))
 
+
+
+;;; # Wrappers
 (defn plot-ehcps-against-year-by-group
   "Wrapper for `line*-plot`s of `data` by `group` supplying defaults for plotting an EHCP projection summary.
 

--- a/src/witan/send/adroddiad/vega_specs/lines.clj
+++ b/src/witan/send/adroddiad/vega_specs/lines.clj
@@ -87,10 +87,10 @@
            y-zero        true
            y-format      ",.0f"
            tooltip-field :tooltip-column}
-    :as   cfg}]
+    :as   plot-spec}]
   (let [tooltip-formatf       (or tooltip-formatf
-                                  (five-number-summary-tooltip (assoc (select-keys cfg [:tooltip-field
-                                                                                        :orl :irl :y :iru :oru])
+                                  (five-number-summary-tooltip (assoc (select-keys plot-spec [:tooltip-field
+                                                                                              :orl :irl :y :iru :oru])
                                                                       :fmt (str "%" (str/replace y-format #"%" "%%")))))
         tooltip-group-formatf (fn [g] (str g " " (->> g
                                                       (get (as-> colors-and-shapes $
@@ -169,10 +169,10 @@
            y-zero        true
            y-scale       false
            tooltip-field :tooltip-column}
-    :as   cfg}]
+    :as   plot-spec}]
   (let [tooltip-formatf (or tooltip-formatf
-                            (five-number-summary-tooltip (assoc (select-keys cfg [:tooltip-field
-                                                                                  :orl :irl :y :iru :oru])
+                            (five-number-summary-tooltip (assoc (select-keys plot-spec [:tooltip-field
+                                                                                        :orl :irl :y :iru :oru])
                                                                 :fmt (str "%" (str/replace y-format #"%" "%%"))
                                                                 :f   identity)))
         tooltip         [{:field group :title group-title}
@@ -235,10 +235,10 @@
            y-zero        true
            y-scale       false
            tooltip-field :tooltip-column}
-    :as   cfg}]
+    :as   plot-spec}]
   (let [tooltip-formatf (or tooltip-formatf
-                            (five-number-summary-tooltip (assoc (select-keys cfg [:tooltip-field
-                                                                                  :orl :irl :y :iru :oru])
+                            (five-number-summary-tooltip (assoc (select-keys plot-spec [:tooltip-field
+                                                                                        :orl :irl :y :iru :oru])
                                                                 :fmt (str "%" (str/replace y-format #"%" "%%"))
                                                                 :f   identity)))
         tooltip         [{:field group :title group-title}


### PR DESCRIPTION
Add processing of `colors-and-shapes` to wrapper `plot-ehcps-against-year-by-group` to:
- provide a default `colors-and-shapes` if none specified, and
- throw an exception if the supplied `:colors-and-shapes` doesn't contain all `group`s in the `data`
