### PR TITLE
Allow specification of y tooltip formats

### DIFF
--- a/src/witan/send/adroddiad/vega_specs/lines.clj
+++ b/src/witan/send/adroddiad/vega_specs/lines.clj
@@ -75,7 +75,7 @@
   [{:keys [data
            chart-title
            x x-title x-format x-scale
-           y y-title y-format y-scale y-zero
+           y y-title y-format y-scale y-zero y-tooltip-format
            orl irl iru oru
            tooltip-field tooltip-formatf
            group group-title
@@ -90,10 +90,11 @@
            tooltip-field :tooltip-column
            legend        true}
     :as   plot-spec}]
-  (let [tooltip-formatf       (or tooltip-formatf
+  (let [y-tooltip-format      (or y-tooltip-format y-format)
+        tooltip-formatf       (or tooltip-formatf
                                   (five-number-summary-tooltip (assoc (select-keys plot-spec [:tooltip-field
                                                                                               :orl :irl :y :iru :oru])
-                                                                      :fmt (str "%" (str/replace y-format #"%" "%%")))))
+                                                                      :fmt (str "%" (str/replace y-tooltip-format #"%" "%%")))))
         tooltip-group-formatf (fn [g] (str g " " (->> g
                                                       (get (as-> colors-and-shapes $
                                                              (zipmap (:domain-value $) (:unicode-shape $)))))))]
@@ -161,7 +162,7 @@
            chart-title
            chart-height chart-width
            x x-title x-format
-           y y-title y-format y-zero y-scale
+           y y-title y-format y-scale y-zero y-tooltip-format
            oru irl iru orl
            tooltip-field tooltip-formatf
            group group-title
@@ -175,13 +176,14 @@
            tooltip-field :tooltip-column
            legend        true}
     :as   plot-spec}]
-  (let [tooltip-formatf (or tooltip-formatf
+  (let [y-tooltip-format (or y-tooltip-format y-format)
+        tooltip-formatf  (or tooltip-formatf
                             (five-number-summary-tooltip (assoc (select-keys plot-spec [:tooltip-field
                                                                                         :orl :irl :y :iru :oru])
-                                                                :fmt (str "%" (str/replace y-format #"%" "%%"))
+                                                                 :fmt (str "%" (str/replace y-tooltip-format #"%" "%%"))
                                                                 :f   identity)))
-        tooltip         [{:field group :title group-title}
-                         {:field x :title x-title :type "temporal" :format x-format }
+        tooltip          [{:field group :title group-title}
+                          {:field x :title x-title :type "temporal" :format x-format}
                          {:field tooltip-field :title y-title}
                          {:field y :title y-title}]]
     {:height   chart-height
@@ -205,7 +207,8 @@
                         :axis   {:format x-format}}
                 :y     {:title y-title
                         :scale {:domain y-scale
-                                :zero   y-zero}}
+                                :zero   y-zero}
+                        :axis   {:format y-format}}
                 :color {:legend legend}}
      :layer    [{:mark     {:type "line"
                             :size 5}
@@ -230,7 +233,7 @@
            chart-title
            chart-height chart-width
            x x-title x-format
-           y y-title y-format y-zero y-scale
+           y y-title y-format y-scale y-zero y-tooltip-format
            oru irl iru orl
            tooltip-field tooltip-formatf
            group group-title
@@ -244,13 +247,14 @@
            tooltip-field :tooltip-column
            legend        true}
     :as   plot-spec}]
-  (let [tooltip-formatf (or tooltip-formatf
+  (let [y-tooltip-format (or y-tooltip-format y-format)
+        tooltip-formatf  (or tooltip-formatf
                             (five-number-summary-tooltip (assoc (select-keys plot-spec [:tooltip-field
                                                                                         :orl :irl :y :iru :oru])
-                                                                :fmt (str "%" (str/replace y-format #"%" "%%"))
+                                                                 :fmt (str "%" (str/replace y-tooltip-format #"%" "%%"))
                                                                 :f   identity)))
         tooltip         [{:field group :title group-title}
-                         {:field x :title x-title :type "temporal" :format x-format }
+                         {:field x :title x-title :type "temporal" :format x-format}
                          {:field tooltip-field :title y-title}
                          {:field y :title y-title}]]
     {:height   chart-height
@@ -274,7 +278,8 @@
                         :axis   {:format x-format}}
                 :y     {:title y-title
                         :scale {:domain y-scale
-                                :zero   y-zero}}
+                                :zero   y-zero}
+                        :axis   {:format y-format}}
                 :color {:legend legend}}
      :layer    [{:mark     {:type  "line"
                             :size  2

--- a/src/witan/send/adroddiad/vega_specs/lines.clj
+++ b/src/witan/send/adroddiad/vega_specs/lines.clj
@@ -304,19 +304,20 @@
            chart-title
            chart-height chart-width
            x x-title x-format
-           y y-title y-format y-scale y-zero y-axis-format
+           y y-title y-format y-scale y-zero y-tooltip-format
            group group-title
            colors-and-shapes
            legend]
     :or   {chart-height vs/full-height
            chart-width  vs/full-width
-           y-format     ".0f"
+           y-format     ",.0f"
            y-zero       true
            y-scale      false
            legend       true}}]
-  (let [tooltip [{:field group :title group-title}
-                 {:field x :title x-title :format x-format :type "temporal"}
-                 {:field y :title y-title :format y-format :type "quantitative"}]]
+  (let [y-tooltip-format (or y-tooltip-format y-format)
+        tooltip          [{:field group :title group-title}
+                          {:field x :title x-title :type "temporal"     :format x-format}
+                          {:field y :title y-title :type "quantitative" :format y-tooltip-format}]]
     {:height   chart-height
      :width    chart-width
      :title    {:text     chart-title
@@ -341,7 +342,7 @@
                 :y     {:title y-title
                         :scale {:domain y-scale
                                 :zero   y-zero}
-                        :axis   {:format (or y-axis-format y-format)}}
+                        :axis   {:format y-format}}
                 :color {:legend legend}}
      :layer    [{:mark     {:type  "line"
                             :size  2

--- a/src/witan/send/adroddiad/vega_specs/lines.clj
+++ b/src/witan/send/adroddiad/vega_specs/lines.clj
@@ -117,12 +117,7 @@
                                     :type  "quantitative"
                                     :axis  {:format y-format}
                                     :scale {:domain y-scale :zero y-zero}}}
-                 :layer    [{:mark {:type  "line"
-                                    :size  5
-                                    :point {:filled      true #_false
-                                            :size        150
-                                            :strokewidth 0.5}}}
-                            {:mark     "errorband"
+                 :layer    [{:mark     "errorband"
                              :encoding {:y       {:field oru :title y-title :type "quantitative"}
                                         :y2      {:field orl}
                                         :color   {:field group :title group-title}
@@ -132,6 +127,11 @@
                                         :y2      {:field irl}
                                         :color   {:field group :title group-title}
                                         :tooltip nil}}
+                            {:mark {:type  "line"
+                                    :size  5
+                                    :point {:filled      true #_false
+                                            :size        150
+                                            :strokewidth 0.5}}}
                             {:transform [{:filter {:param "hover" :empty false}}] :mark {:type "point" :size 200 :strokeWidth 5}}]}
                 {:data     {:values (-> data
                                         tooltip-formatf
@@ -178,14 +178,14 @@
     :as   plot-spec}]
   (let [y-tooltip-format (or y-tooltip-format y-format)
         tooltip-formatf  (or tooltip-formatf
-                            (five-number-summary-tooltip (assoc (select-keys plot-spec [:tooltip-field
-                                                                                        :orl :irl :y :iru :oru])
+                             (five-number-summary-tooltip (assoc (select-keys plot-spec [:tooltip-field
+                                                                                         :orl :irl :y :iru :oru])
                                                                  :fmt (str "%" (str/replace y-tooltip-format #"%" "%%"))
-                                                                :f   identity)))
+                                                                 :f   identity)))
         tooltip          [{:field group :title group-title}
                           {:field x :title x-title :type "temporal" :format x-format}
-                         {:field tooltip-field :title y-title}
-                         {:field y :title y-title}]]
+                          {:field tooltip-field :title y-title}
+                          {:field y :title y-title}]]
     {:height   chart-height
      :width    chart-width
      :title    {:text     chart-title
@@ -210,21 +210,21 @@
                                 :zero   y-zero}
                         :axis   {:format y-format}}
                 :color {:legend legend}}
-     :layer    [{:mark     {:type "line"
-                            :size 5}
-                 :encoding {:y       {:field y :type "quantitative"}
-                            ;; color and shape scale and range must be specified or you get extra things in the legend
-                            :color   (vs/color-map data group colors-and-shapes)
+     :layer    [{:mark     "errorband"
+                 :encoding {:y       {:field oru :type "quantitative"}
+                            :y2      {:field orl}
+                            :color   {:field group :title group-title}
                             :tooltip tooltip}}
                 {:mark     "errorband"
                  :encoding {:y       {:field iru :type "quantitative"}
                             :y2      {:field irl}
                             :color   {:field group :title group-title}
                             :tooltip tooltip}}
-                {:mark     "errorband"
-                 :encoding {:y       {:field oru :type "quantitative"}
-                            :y2      {:field orl}
-                            :color   {:field group :title group-title}
+                {:mark     {:type "line"
+                            :size 5}
+                 :encoding {:y       {:field y :type "quantitative"}
+                            ;; color and shape scale and range must be specified or you get extra things in the legend
+                            :color   (vs/color-map data group colors-and-shapes)
                             :tooltip tooltip}}]}))
 
 (defn line-shape-and-ribbon-plot
@@ -249,10 +249,10 @@
     :as   plot-spec}]
   (let [y-tooltip-format (or y-tooltip-format y-format)
         tooltip-formatf  (or tooltip-formatf
-                            (five-number-summary-tooltip (assoc (select-keys plot-spec [:tooltip-field
-                                                                                        :orl :irl :y :iru :oru])
+                             (five-number-summary-tooltip (assoc (select-keys plot-spec [:tooltip-field
+                                                                                         :orl :irl :y :iru :oru])
                                                                  :fmt (str "%" (str/replace y-tooltip-format #"%" "%%"))
-                                                                :f   identity)))
+                                                                 :f   identity)))
         tooltip         [{:field group :title group-title}
                          {:field x :title x-title :type "temporal" :format x-format}
                          {:field tooltip-field :title y-title}
@@ -281,7 +281,17 @@
                                 :zero   y-zero}
                         :axis   {:format y-format}}
                 :color {:legend legend}}
-     :layer    [{:mark     {:type  "line"
+     :layer    [{:mark     "errorband"
+                 :encoding {:y       {:field oru :type "quantitative"}
+                            :y2      {:field orl}
+                            :color   {:field group :title group-title}
+                            :tooltip tooltip}}
+                {:mark     "errorband"
+                 :encoding {:y       {:field iru :type "quantitative"}
+                            :y2      {:field irl}
+                            :color   {:field group :title group-title}
+                            :tooltip tooltip}}
+                {:mark     {:type  "line"
                             :size  2
                             :point {:filled      false
                                     :fill        "white"
@@ -291,16 +301,6 @@
                             ;; color and shape scale and range must be specified or you get extra things in the legend
                             :color   (vs/color-map data group colors-and-shapes)
                             :shape   (vs/shape-map data group colors-and-shapes)
-                            :tooltip tooltip}}
-                {:mark     "errorband"
-                 :encoding {:y       {:field iru :type "quantitative"}
-                            :y2      {:field irl}
-                            :color   {:field group :title group-title}
-                            :tooltip tooltip}}
-                {:mark     "errorband"
-                 :encoding {:y       {:field oru :type "quantitative"}
-                            :y2      {:field orl}
-                            :color   {:field group :title group-title}
                             :tooltip tooltip}}]}))
 
 (defn line-plot

--- a/src/witan/send/adroddiad/vega_specs/lines.clj
+++ b/src/witan/send/adroddiad/vega_specs/lines.clj
@@ -310,13 +310,13 @@
            legend]
     :or   {chart-height vs/full-height
            chart-width  vs/full-width
-           #_#_y-format ".0f"
+           y-format     ".0f"
            y-zero       true
            y-scale      false
            legend       true}}]
   (let [tooltip [{:field group :title group-title}
                  {:field x :title x-title :format x-format :type "temporal"}
-                 {:field y :title y-title #_#_:format y-format}]]
+                 {:field y :title y-title :format y-format :type "quantitative"}]]
     {:height   chart-height
      :width    chart-width
      :title    {:text     chart-title

--- a/src/witan/send/adroddiad/vega_specs/lines.clj
+++ b/src/witan/send/adroddiad/vega_specs/lines.clj
@@ -304,7 +304,7 @@
            chart-title
            chart-height chart-width
            x x-title x-format
-           y y-title y-format y-zero y-scale
+           y y-title y-format y-scale y-zero y-axis-format
            group group-title
            colors-and-shapes
            legend]
@@ -340,7 +340,8 @@
                         :axis   {:format x-format}}
                 :y     {:title y-title
                         :scale {:domain y-scale
-                                :zero   y-zero}}
+                                :zero   y-zero}
+                        :axis   {:format (or y-axis-format y-format)}}
                 :color {:legend legend}}
      :layer    [{:mark     {:type  "line"
                             :size  2


### PR DESCRIPTION
- Enable y-value formatting in all plots.
- Allow separate formatting of y values in tooltips if specified.
- Also re-order layers so lines are on top of ribbons.